### PR TITLE
Change tree module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod lexer;
 pub mod parser;
 mod token;
-mod tree;
+pub mod tree;


### PR DESCRIPTION
Changes:
Made the node type in the tree module public (pub).
This allows users of the crate to directly access and utilize the node type.

Purpose:
The goal of this change is to enable crate users to customize or manipulate the node type, making it more flexible for their use cases.